### PR TITLE
Close prepared statements after fetching results

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -406,7 +406,9 @@ function getLetzterEintrag($fahrzeug_id, $kategorie) {
     ");
     $stmt->bind_param("is", $fahrzeug_id, $kategorie);
     $stmt->execute();
-    return $stmt->get_result()->fetch_assoc();
+    $eintrag = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    return $eintrag;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Prevent resource leaks by closing the mysqli statement in `getLetzterEintrag`

## Testing
- `php -l includes/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a36e97f0ec832ebd5fd51c3f1f57fa