### PR TITLE
Fix consumption calculations and extend stats

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -168,6 +168,28 @@ function berechneKraftstoffkostenProKm(int $fid): ?float
     return ($d['km'] > 0) ? round($d['k'] / $d['km'], 4) : null;
 }
 
+function berechneDurchschnittPreisProLiter(int $fid): ?float
+{
+    global $conn;
+    $st = $conn->prepare("SELECT SUM(kosten) AS k, SUM(menge) AS m FROM eintraege WHERE fahrzeug_id=? AND kategorie='Tankfuellung'");
+    $st->bind_param('i', $fid);
+    $st->execute();
+    $d = $st->get_result()->fetch_assoc();
+    $st->close();
+    return ($d['m'] > 0) ? round($d['k'] / $d['m'], 3) : null;
+}
+
+function getInitialTachostand(int $fid): ?int
+{
+    global $conn;
+    $st = $conn->prepare('SELECT tachostand FROM fahrzeuge WHERE id=? LIMIT 1');
+    $st->bind_param('i', $fid);
+    $st->execute();
+    $row = $st->get_result()->fetch_assoc();
+    $st->close();
+    return $row ? (int)$row['tachostand'] : null;
+}
+
 // --------------------------------------------------
 // 4. Statistikdatensätze (für Tab "Statistiken")
 // --------------------------------------------------
@@ -175,26 +197,30 @@ function holeVerbrauchswerte(int $fahrzeug_id): array
 {
     global $conn;
     $verbrauchswerte = [];
-    $stmt = $conn->prepare("
-        SELECT datum, menge, tachostand 
-        FROM eintraege 
-        WHERE fahrzeug_id = ? 
-          AND kategorie = 'Tankfuellung' 
-          AND vollgetankt = 1 
-        ORDER BY datum
-    ");
+    $stmt = $conn->prepare(
+        "SELECT datum, menge, tachostand, vollgetankt
+         FROM eintraege
+         WHERE fahrzeug_id = ?
+           AND kategorie = 'Tankfuellung'
+         ORDER BY datum"
+    );
     $stmt->bind_param('i', $fahrzeug_id);
     $stmt->execute();
     $res = $stmt->get_result();
-    $previous = null;
+    $letzteVoll = null;
+    $mengeSeitVoll = 0;
     while ($row = $res->fetch_assoc()) {
-        if ($previous) {
-            $gefahrene_km = $row['tachostand'] - $previous['tachostand'];
-            if ($gefahrene_km > 0) {
-                $verbrauchswerte[$row['datum']] = round(($row['menge'] / $gefahrene_km) * 100, 2);
+        $mengeSeitVoll += $row['menge'];
+        if ($row['vollgetankt']) {
+            if ($letzteVoll) {
+                $km = $row['tachostand'] - $letzteVoll['tachostand'];
+                if ($km > 0) {
+                    $verbrauchswerte[$row['datum']] = round(($mengeSeitVoll / $km) * 100, 2);
+                }
             }
+            $letzteVoll = $row;
+            $mengeSeitVoll = 0;
         }
-        $previous = $row;
     }
     $stmt->close();
     return $verbrauchswerte;
@@ -203,28 +229,32 @@ function holeVerbrauchswerte(int $fahrzeug_id): array
 function holeVerbrauchProMonat(int $fahrzeug_id): array
 {
     global $conn;
-    $stmt = $conn->prepare("
-        SELECT DATE_FORMAT(datum, '%Y-%m') AS monat, menge, tachostand 
-        FROM eintraege 
-        WHERE fahrzeug_id = ? 
-          AND kategorie = 'Tankfuellung' 
-          AND vollgetankt = 1 
-        ORDER BY datum
-    ");
+    $stmt = $conn->prepare(
+        "SELECT datum, menge, tachostand, vollgetankt
+         FROM eintraege
+         WHERE fahrzeug_id = ?
+           AND kategorie = 'Tankfuellung'
+         ORDER BY datum"
+    );
     $stmt->bind_param('i', $fahrzeug_id);
     $stmt->execute();
     $res = $stmt->get_result();
     $zwischen = [];
-    $previous = null;
+    $letzteVoll = null;
+    $mengeSeitVoll = 0;
     while ($row = $res->fetch_assoc()) {
-        if ($previous) {
-            $monat = $row['monat'];
-            $gefahrene_km = $row['tachostand'] - $previous['tachostand'];
-            if ($gefahrene_km > 0) {
-                $zwischen[$monat][] = ($row['menge'] / $gefahrene_km) * 100;
+        $mengeSeitVoll += $row['menge'];
+        if ($row['vollgetankt']) {
+            if ($letzteVoll) {
+                $km = $row['tachostand'] - $letzteVoll['tachostand'];
+                if ($km > 0) {
+                    $monat = date('Y-m', strtotime($row['datum']));
+                    $zwischen[$monat][] = ($mengeSeitVoll / $km) * 100;
+                }
             }
+            $letzteVoll = $row;
+            $mengeSeitVoll = 0;
         }
-        $previous = $row;
     }
     $stmt->close();
     $verbrauchProMonat = [];
@@ -259,32 +289,24 @@ function holeJahresdaten(int $fahrzeug_id): array
 {
     global $conn;
     $jahresdaten = [];
-    $stmt = $conn->prepare("
-        SELECT YEAR(datum) AS jahr, SUM(menge) AS gesamt_menge, COUNT(*) AS stops, SUM(kosten) AS gesamt_ausgaben
-        FROM eintraege
-        WHERE fahrzeug_id = ? 
-          AND kategorie = 'Tankfuellung' 
-          AND vollgetankt = 1
-        GROUP BY jahr
-        ORDER BY jahr DESC
-    ");
+    $stmt = $conn->prepare(
+        "SELECT YEAR(datum) AS jahr,
+                SUM(menge) AS gesamt_menge,
+                COUNT(*) AS stops,
+                SUM(kosten) AS gesamt_ausgaben,
+                MAX(tachostand) AS max_tacho,
+                MIN(tachostand) AS min_tacho
+         FROM eintraege
+         WHERE fahrzeug_id = ?
+           AND kategorie = 'Tankfuellung'
+         GROUP BY jahr
+         ORDER BY jahr DESC"
+    );
     $stmt->bind_param('i', $fahrzeug_id);
     $stmt->execute();
     $res = $stmt->get_result();
     while ($row = $res->fetch_assoc()) {
-        $sub = $conn->prepare("
-            SELECT MAX(tachostand) - MIN(tachostand) AS km 
-            FROM eintraege 
-            WHERE fahrzeug_id = ? 
-              AND kategorie = 'Tankfuellung' 
-              AND vollgetankt = 1 
-              AND YEAR(datum) = ?
-        ");
-        $sub->bind_param('ii', $fahrzeug_id, $row['jahr']);
-        $sub->execute();
-        $km_result = $sub->get_result()->fetch_assoc();
-        $sub->close();
-        $gefahrene_km = $km_result['km'] ?? 0;
+        $gefahrene_km = ($row['max_tacho'] ?? 0) - ($row['min_tacho'] ?? 0);
         $jahresdaten[$row['jahr']] = [
             'anzahl_tankstops' => $row['stops'],
             'gesamt_menge' => $row['gesamt_menge'],

--- a/tabs/ausgaben.php
+++ b/tabs/ausgaben.php
@@ -20,6 +20,18 @@ $gesamtKosten = array_sum($beträge);
 // Detailtabelle vorbereiten
 $detailDaten = holeDetailAusgabenDaten($fahrzeug_id, $selectedYear);
 
+// Zusätzliche Kennzahlen
+$anzahlMonate = holeAnzahlMonate($fahrzeug_id, $selectedYear);
+$durchschnittMonat = $anzahlMonate > 0 ? $gesamtKosten / $anzahlMonate : 0;
+$topKategorie = '-';
+$topSumme = 0;
+foreach ($detailDaten as $k => $daten) {
+    if ($daten['summe'] > $topSumme) {
+        $topKategorie = $k;
+        $topSumme = $daten['summe'];
+    }
+}
+
 // Farben für Kategorien definieren
 function getCategoryColor($kategorie) {
     $colors = [
@@ -44,6 +56,27 @@ $farben = array_map('getCategoryColor', $kategorien);
 
 <div class="mt-4">
     <h3>Ausgabenanalyse</h3>
+
+    <div class="row mb-4">
+        <div class="col-md-4 mb-2">
+            <div class="card p-2 text-center">
+                <strong>Gesamtausgaben</strong><br>
+                <span><?php echo number_format($gesamtKosten, 2, ',', '.'); ?> €</span>
+            </div>
+        </div>
+        <div class="col-md-4 mb-2">
+            <div class="card p-2 text-center">
+                <strong>Ø Ausgaben pro Monat</strong><br>
+                <span><?php echo number_format($durchschnittMonat, 2, ',', '.'); ?> €</span>
+            </div>
+        </div>
+        <div class="col-md-4 mb-2">
+            <div class="card p-2 text-center">
+                <strong>Größte Kostenkategorie</strong><br>
+                <span><?php echo htmlspecialchars(getKategorieName($topKategorie)); ?></span>
+            </div>
+        </div>
+    </div>
     
     <!-- Filter nach Jahr -->
     <form method="get" action="" class="mb-3">
@@ -130,7 +163,7 @@ $farben = array_map('getCategoryColor', $kategorien);
                     <?php
                     // Aktuellen Tachostand und initialen Tachostand holen
                     $aktTachostand = getAktuellenTachostand($fahrzeug_id);
-                    $initialTachostand = 0; // TODO: Aus Datenbank holen
+                    $initialTachostand = getInitialTachostand($fahrzeug_id) ?? 0;
                     $gefahreneKm = $aktTachostand - $initialTachostand;
                     $kostenProKm = $gefahreneKm > 0 ? $gesamtKosten / $gefahreneKm : 0;
                     ?>
@@ -306,5 +339,25 @@ function holeVerfügbareJahre($fahrzeug_id) {
     }
     
     return $jahre;
+}
+
+function holeAnzahlMonate($fahrzeug_id, $jahr = null) {
+    global $conn;
+
+    $sql = "SELECT COUNT(DISTINCT DATE_FORMAT(datum, '%Y-%m')) AS monate FROM eintraege WHERE fahrzeug_id = ?";
+    if ($jahr !== null) {
+        $sql .= " AND YEAR(datum) = ?";
+    }
+
+    $stmt = $conn->prepare($sql);
+    if ($jahr !== null) {
+        $stmt->bind_param('ii', $fahrzeug_id, $jahr);
+    } else {
+        $stmt->bind_param('i', $fahrzeug_id);
+    }
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    return (int)($row['monate'] ?? 0);
 }
 ?>

--- a/tabs/statistiken.php
+++ b/tabs/statistiken.php
@@ -17,6 +17,8 @@ $verbrauchswerte              = holeVerbrauchswerte($fahrzeug_id) ?: [];
 $verbrauchProMonat             = holeVerbrauchProMonat($fahrzeug_id) ?: [];
 $kostenProMonat                = holeKostenProMonat($fahrzeug_id) ?: [];
 $jahresdaten                   = holeJahresdaten($fahrzeug_id) ?: [];
+$kraftstoffKostenProKm         = berechneKraftstoffkostenProKm($fahrzeug_id);
+$durchschnittPreis             = berechneDurchschnittPreisProLiter($fahrzeug_id);
 
 // Kennzahlen berechnen
 $minVerbrauch                  = $verbrauchswerte ? min($verbrauchswerte) : 0;
@@ -85,6 +87,34 @@ $teuersterMonatWert  = !empty($kostenProMonatFormatted)    ? max($kostenProMonat
                 <?php
                     echo $teuersterMonatWert !== null
                          ? $teuersterKey.' ('.number_format($teuersterMonatWert, 2, ',', '.').' €)'
+                         : '–';
+                ?>
+            </span>
+        </div>
+    </div>
+</div>
+
+<!-- Zusätzliche Kennzahlen -->
+<div class="row mb-4">
+    <div class="col-md-6 mb-2">
+        <div class="card p-2 text-center">
+            <strong>Kraftstoffkosten pro km</strong><br>
+            <span>
+                <?php
+                    echo $kraftstoffKostenProKm !== null
+                         ? number_format($kraftstoffKostenProKm, 2, ',', '.').' €'
+                         : '–';
+                ?>
+            </span>
+        </div>
+    </div>
+    <div class="col-md-6 mb-2">
+        <div class="card p-2 text-center">
+            <strong>Ø Kraftstoffpreis</strong><br>
+            <span>
+                <?php
+                    echo $durchschnittPreis !== null
+                         ? number_format($durchschnittPreis, 3, ',', '.').' €/l'
                          : '–';
                 ?>
             </span>


### PR DESCRIPTION
## Summary
- include partial fuel-ups in consumption metrics and annual summaries
- display fuel cost per km and average fuel price
- enhance expenses tab with monthly averages, top category and correct km basis

## Testing
- `php -l includes/functions.php`
- `php -l tabs/statistiken.php`
- `php -l tabs/ausgaben.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3768e4134832e80f73386de9388cf