### PR TITLE
Properly save and display trip entries

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -47,7 +47,7 @@ CREATE TABLE `eintraege` (
   `id` int(32) NOT NULL,
   `fahrzeug_id` int(32) NOT NULL,
   `kraftstoff` ENUM('diesel','e5','e10','lpg','cng','electric','hybrid','hydrogen','other') DEFAULT NULL,
-  `kategorie` enum('Tankfuellung','Versicherung','Steuer','Inspektion','Reparatur','Reifen','TUV','Wartung','Dekor','Verbrauch') NOT NULL,
+  `kategorie` enum('Tankfuellung','Versicherung','Steuer','Inspektion','Reparatur','Reifen','TUV','Wartung','Dekor','Verbrauch','Fahrt') NOT NULL,
   `datum` date NOT NULL,
   `tachostand` int(64) NOT NULL,
   `standort` varchar(128) NOT NULL,
@@ -57,7 +57,11 @@ CREATE TABLE `eintraege` (
   `vollgetankt` bit(1) NOT NULL,
   `standort_bezeichnung` varchar(32) NOT NULL,
   `beschreibung` text NOT NULL,
-  `skip_previous` bit(1) NOT NULL
+  `skip_previous` bit(1) NOT NULL,
+  `startort` varchar(128) NOT NULL DEFAULT '',
+  `zielort` varchar(128) NOT NULL DEFAULT '',
+  `zweck` varchar(255) NOT NULL DEFAULT '',
+  `gefahrene_km` decimal(32,4) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,6 +17,7 @@ function getCategoryIcon(string $kategorie): string
         'Wartung'      => 'fa-cogs',
         'Dekor'        => 'fa-paint-roller',
         'Verbrauch'    => 'fa-chart-line',
+        'Fahrt'        => 'fa-route',
     ];
     return $icons[$kategorie] ?? 'fa-question-circle';
 }

--- a/pages/eintrag_speichern.php
+++ b/pages/eintrag_speichern.php
@@ -29,7 +29,12 @@ $data = [
     'skip_previous'=> 0,
     'beschreibung' => '',
     // Schema verlangt NOT NULL für standort_bezeichnung
-    'standort_bezeichnung' => ''
+    'standort_bezeichnung' => '',
+    // Felder für Fahrten
+    'startort'       => '',
+    'zielort'        => '',
+    'zweck'          => '',
+    'gefahrene_km'   => 0
 ];
 
 // Verarbeitung nach Typ
@@ -52,11 +57,11 @@ switch ($eintragstyp) {
         break;
 
     case 'Fahrt':
-        // Hinweis: Die aktuelle Tabellenstruktur enthält keine Spalten für Fahrt-Details.
-        // Wir speichern daher nur eine Ausgabe unter Kategorie 'Wartung' mit Beschreibung.
-        $data['kategorie']    = 'Wartung';
-        $data['beschreibung'] = trim($_POST['zweck'] ?? 'Fahrt');
-        $data['kosten']       = 0;
+        $data['kategorie']    = 'Fahrt';
+        $data['startort']     = trim($_POST['startort'] ?? '');
+        $data['zielort']      = trim($_POST['zielort'] ?? '');
+        $data['zweck']        = trim($_POST['zweck'] ?? '');
+        $data['gefahrene_km'] = isset($_POST['gefahrene_km']) ? floatval($_POST['gefahrene_km']) : 0;
         break;
 
     default:

--- a/tabs/ausgaben.php
+++ b/tabs/ausgaben.php
@@ -45,7 +45,8 @@ function getCategoryColor($kategorie) {
         'TUV'          => 'rgba(255, 99, 71, 0.7)',     // Tomate
         'Wartung'      => 'rgba(60, 179, 113, 0.7)',    // Grün
         'Dekor'        => 'rgba(238, 130, 238, 0.7)',   // Violett
-        'Verbrauch'    => 'rgba(106, 90, 205, 0.7)'     // Slate Blue
+        'Verbrauch'    => 'rgba(106, 90, 205, 0.7)',    // Slate Blue
+        'Fahrt'        => 'rgba(30, 144, 255, 0.7)'     // DodgerBlue
     ];
     return $colors[$kategorie] ?? 'rgba(169, 169, 169, 0.7)'; // Standard: Dunkelgrau
 }

--- a/tabs/eintraege.php
+++ b/tabs/eintraege.php
@@ -29,9 +29,18 @@ while ($row = $res->fetch_assoc()) {
 $stmt->close();
 
 $farben = [
-    'Tankfuellung' => 'primary','Versicherung'=>'success','Werkstatt'=>'warning',
-    'Inspektion'=>'info','Reparatur'=>'danger','Reifen'=>'secondary',
-    'TUV'=>'dark','Wartung'=>'warning','Dekor'=>'info','Verbrauch'=>'secondary'];
+    'Tankfuellung' => 'primary',
+    'Versicherung' => 'success',
+    'Werkstatt'    => 'warning',
+    'Inspektion'   => 'info',
+    'Reparatur'    => 'danger',
+    'Reifen'       => 'secondary',
+    'TUV'          => 'dark',
+    'Wartung'      => 'warning',
+    'Dekor'        => 'info',
+    'Verbrauch'    => 'secondary',
+    'Fahrt'        => 'info'
+];
 ?>
 
 <style>


### PR DESCRIPTION
## Summary
- store "Fahrt" entries with their own category and trip fields
- add icons and color mappings for trip entries
- extend schema to support trip-specific columns

## Testing
- `php -l includes/functions.php`
- `php -l pages/eintrag_speichern.php`
- `php -l tabs/eintraege.php`
- `php -l tabs/ausgaben.php`


------
https://chatgpt.com/codex/tasks/task_e_68a431bb811c832eb1cfdcfefc2b830d