### PR TITLE
Leverage trip entries for monthly cost stats

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -268,21 +268,72 @@ function holeVerbrauchProMonat(int $fahrzeug_id): array
 function holeKostenProMonat(int $fahrzeug_id): array
 {
     global $conn;
+
     $kostenProMonat = [];
-    $stmt = $conn->prepare("
-        SELECT DATE_FORMAT(datum, '%Y-%m') AS monat, SUM(kosten) AS summe
-        FROM eintraege 
-        WHERE fahrzeug_id = ?
-        GROUP BY monat
-        ORDER BY monat ASC
-    ");
+
+    // 1) Gesamtkosten ermitteln
+    $stmt = $conn->prepare('SELECT SUM(kosten) AS summe FROM eintraege WHERE fahrzeug_id = ?');
+    $stmt->bind_param('i', $fahrzeug_id);
+    $stmt->execute();
+    $totalKosten = (float)($stmt->get_result()->fetch_assoc()['summe'] ?? 0);
+    $stmt->close();
+
+    if ($totalKosten <= 0) {
+        return $kostenProMonat;
+    }
+
+    // 2) Kilometer pro Monat aus Fahrten ermitteln
+    $stmt = $conn->prepare(
+        "SELECT DATE_FORMAT(datum, '%Y-%m') AS monat, SUM(gefahrene_km) AS km\n         FROM eintraege\n         WHERE fahrzeug_id = ? AND kategorie = 'Fahrt'\n         GROUP BY monat\n         ORDER BY monat ASC"
+    );
     $stmt->bind_param('i', $fahrzeug_id);
     $stmt->execute();
     $res = $stmt->get_result();
+    $kmData = [];
+    $totalKm = 0.0;
     while ($row = $res->fetch_assoc()) {
-        $kostenProMonat[$row['monat']] = round($row['summe'], 2);
+        $kmData[$row['monat']] = (float)$row['km'];
+        $totalKm += (float)$row['km'];
     }
     $stmt->close();
+
+    if ($totalKm > 0) {
+        foreach ($kmData as $monat => $km) {
+            $kostenProMonat[$monat] = round($totalKosten * ($km / $totalKm), 2);
+        }
+        return $kostenProMonat;
+    }
+
+    // 3) Fallback: Verteilung nach Tagen
+    $stmt = $conn->prepare('SELECT MIN(datum) AS min_datum, MAX(datum) AS max_datum FROM eintraege WHERE fahrzeug_id = ?');
+    $stmt->bind_param('i', $fahrzeug_id);
+    $stmt->execute();
+    $range = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$range['min_datum'] || !$range['max_datum']) {
+        return $kostenProMonat;
+    }
+
+    $minDate = new DateTime($range['min_datum']);
+    $maxDate = new DateTime($range['max_datum']);
+    $totalDays = $maxDate->diff($minDate)->days + 1;
+
+    $start = (clone $minDate)->modify('first day of this month');
+    $end = (clone $maxDate)->modify('first day of next month');
+    $interval = new DateInterval('P1M');
+    $period = new DatePeriod($start, $interval, $end);
+
+    foreach ($period as $dt) {
+        $monthStart = $dt > $minDate ? clone $dt : clone $minDate;
+        $monthEnd = (clone $dt)->modify('last day of this month');
+        if ($monthEnd > $maxDate) {
+            $monthEnd = $maxDate;
+        }
+        $days = $monthEnd->diff($monthStart)->days + 1;
+        $kostenProMonat[$dt->format('Y-m')] = round($totalKosten * ($days / $totalDays), 2);
+    }
+
     return $kostenProMonat;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ Willkommen zum **Fahrzeug-Tracker-Projekt**! Diese Webanwendung ermöglicht es B
   - Anzeige von Minimal-, Durchschnitts- und Maximalverbrauchswerten.
 - **Jahresübersicht**:
   - Tabelle mit jährlichen Daten wie Anzahl der Tankstops, Gesamtmenge getankter Liter/kWh, durchschnittlicher Verbrauch und Gesamtausgaben.
+- **Monatliche Ausgaben**:
+  - Bei vorhandenen Fahrten werden die Gesamtkosten anhand der gefahrenen Kilometer auf die Monate verteilt; ohne Fahrten erfolgt die Verteilung weiterhin tagbasiert.
 
 ### 5. Ausgabenanalyse (Reiter 4)
 


### PR DESCRIPTION
## Summary
- Distribute total costs across months using recorded trip kilometers when available
- Document that monthly expenses prefer trip data and fall back to day-based distribution

## Testing
- `php -l includes/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a1a33a44832eab92098025a2904d