### PR TITLE
Fix monthly consumption stats and add weighted calculations

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -346,27 +346,43 @@ function holeVerbrauchProMonat(int $fahrzeug_id): array
     $stmt->bind_param('i', $fahrzeug_id);
     $stmt->execute();
     $res = $stmt->get_result();
+    $rows = [];
+    while ($row = $res->fetch_assoc()) {
+        $rows[] = $row;
+    }
+    $stmt->close();
+    return berechneVerbrauchProMonatAusTankfuellungen($rows);
+}
+
+function berechneVerbrauchProMonatAusTankfuellungen(array $rows): array
+{
     $zwischen = [];
     $letzteVoll = null;
-    $mengeSeitVoll = 0;
-    while ($row = $res->fetch_assoc()) {
-        $mengeSeitVoll += $row['menge'];
+    $mengeSeitVoll = 0.0;
+    foreach ($rows as $row) {
+        $mengeSeitVoll += (float)$row['menge'];
         if ($row['vollgetankt']) {
             if ($letzteVoll) {
                 $km = $row['tachostand'] - $letzteVoll['tachostand'];
                 if ($km > 0) {
                     $monat = date('Y-m', strtotime($row['datum']));
-                    $zwischen[$monat][] = ($mengeSeitVoll / $km) * 100;
+                    if (!isset($zwischen[$monat])) {
+                        $zwischen[$monat] = ['liter' => 0.0, 'km' => 0];
+                    }
+                    $zwischen[$monat]['liter'] += $mengeSeitVoll;
+                    $zwischen[$monat]['km']    += $km;
                 }
             }
             $letzteVoll = $row;
-            $mengeSeitVoll = 0;
+            $mengeSeitVoll = 0.0;
         }
     }
-    $stmt->close();
+
     $verbrauchProMonat = [];
-    foreach ($zwischen as $monat => $werte) {
-        $verbrauchProMonat[$monat] = round(array_sum($werte) / count($werte), 2);
+    foreach ($zwischen as $monat => $daten) {
+        $verbrauchProMonat[$monat] = $daten['km'] > 0
+            ? round(($daten['liter'] / $daten['km']) * 100, 2)
+            : 0.0;
     }
     return $verbrauchProMonat;
 }

--- a/tabs/statistiken.php
+++ b/tabs/statistiken.php
@@ -32,8 +32,8 @@ $kostenProMonatFormatted       = formatLabels($kostenProMonat);
 
 // Zusammenfassung ermitteln mit Guards
 if ($verbrauchProMonatFormatted) {
-    $bestKey    = array_keys($verbrauchProMonatFormatted, max($verbrauchProMonatFormatted))[0];
-    $worstKey   = array_keys($verbrauchProMonatFormatted, min($verbrauchProMonatFormatted))[0];
+    $bestKey    = array_keys($verbrauchProMonatFormatted, min($verbrauchProMonatFormatted))[0];
+    $worstKey   = array_keys($verbrauchProMonatFormatted, max($verbrauchProMonatFormatted))[0];
 } else {
     $bestKey = $worstKey = '-';
 }
@@ -55,7 +55,8 @@ $teuersterMonatWert  = !empty($kostenProMonatFormatted)    ? max($kostenProMonat
     <!-- Bester Verbrauch -->
     <div class="col-md-4 mb-2">
         <div class="card p-2 text-center">
-            <strong>Bester Verbrauch</strong><br>
+            <strong>Bester Monatsverbrauch</strong><br>
+            <small>Basis: Full-to-Full, Monat = Enddatum</small><br>
             <span>
                 <?php
                     echo $besterVerbrauch !== null
@@ -69,7 +70,8 @@ $teuersterMonatWert  = !empty($kostenProMonatFormatted)    ? max($kostenProMonat
     <!-- Schlechtester Verbrauch -->
     <div class="col-md-4 mb-2">
         <div class="card p-2 text-center">
-            <strong>Schlechtester Verbrauch</strong><br>
+            <strong>Schlechtester Monatsverbrauch</strong><br>
+            <small>Basis: Full-to-Full, Monat = Enddatum</small><br>
             <span>
                 <?php
                     echo $schlechtesterVerbrauch !== null

--- a/tests/VerbrauchProMonatTest.php
+++ b/tests/VerbrauchProMonatTest.php
@@ -1,0 +1,19 @@
+<?php
+require __DIR__ . '/../includes/functions.php';
+
+$entries = [
+    ['datum' => '2025-05-08', 'menge' => 47.2, 'tachostand' => 60092, 'vollgetankt' => 1],
+    ['datum' => '2025-05-26', 'menge' => 27.5, 'tachostand' => 60495, 'vollgetankt' => 1],
+    ['datum' => '2025-06-14', 'menge' => 13.2, 'tachostand' => 60695, 'vollgetankt' => 1],
+    ['datum' => '2025-06-26', 'menge' => 20.0, 'tachostand' => 60830, 'vollgetankt' => 0],
+    ['datum' => '2025-07-05', 'menge' => 21.8, 'tachostand' => 61020, 'vollgetankt' => 1],
+    ['datum' => '2025-07-24', 'menge' => 16.9, 'tachostand' => 61280, 'vollgetankt' => 1],
+];
+
+$result = berechneVerbrauchProMonatAusTankfuellungen($entries);
+
+assert(abs($result['2025-05'] - 6.82) < 0.01, 'Mai 2025 expected 6.82');
+assert(abs($result['2025-06'] - 6.60) < 0.01, 'Jun 2025 expected 6.60');
+assert(abs($result['2025-07'] - 10.03) < 0.01, 'Jul 2025 expected ~10.03');
+
+echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- compute monthly fuel consumption using kilometer-weighted averages
- fix best/worst consumption tiles and clarify their labels
- add regression test for monthly consumption calculation

## Testing
- `php -l includes/functions.php`
- `php -l tabs/statistiken.php`
- `php -l tests/VerbrauchProMonatTest.php`
- `php tests/VerbrauchProMonatTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecba6ccc832e9776ac6b88697615