### PR TITLE
Centralize session init and set session cookie Path=/ to fix login persistence

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -54,7 +54,14 @@ if (isApiAuthenticated()) {
             clearApiToken();
             $_SESSION = array();
             if (isset($_COOKIE[session_name()])) {
-                setcookie(session_name(), '', time() - 3600, '/', '', true, true);
+                $sessionCookieOptions = getSessionCookieOptions();
+                setcookie(session_name(), '', [
+                    'expires' => time() - 3600,
+                    'path' => $sessionCookieOptions['path'],
+                    'secure' => $sessionCookieOptions['secure'],
+                    'httponly' => $sessionCookieOptions['httponly'],
+                    'samesite' => $sessionCookieOptions['samesite'],
+                ]);
             }
             session_destroy();
             header('Location: ' . $baseUrl . 'pages/login.php');

--- a/includes/session.php
+++ b/includes/session.php
@@ -1,32 +1,33 @@
 <?php
 
-// Dynamische Session-Cookie-Parameter (funktioniert in beliebigem Unterordner und mit http/https)
-$isHttps = (
-    (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] && $_SERVER['HTTPS'] !== 'off')
-    || (isset($_SERVER['SERVER_PORT']) && (int)$_SERVER['SERVER_PORT'] === 443)
-    || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
-);
-
-// Basis-Pfad der App relativ zum Document-Root ermitteln (z.B. "/fuelstat")
-$docRoot   = rtrim(str_replace('\\', '/', $_SERVER['DOCUMENT_ROOT'] ?? ''), '/');
-$appRootFs = str_replace('\\', '/', realpath(__DIR__ . '/..'));
-$basePath  = rtrim(str_replace($docRoot, '', $appRootFs), '/');
-if ($basePath === '' || $basePath[0] !== '/') {
-    $basePath = '/' . ltrim($basePath, '/');
+if (!function_exists('isHttpsRequest')) {
+    function isHttpsRequest(): bool
+    {
+        return (
+            (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] && $_SERVER['HTTPS'] !== 'off')
+            || (isset($_SERVER['SERVER_PORT']) && (int)$_SERVER['SERVER_PORT'] === 443)
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+        );
+    }
 }
-// Cookie-Pfad soll immer mit Slash enden und mindestens "/"
-$cookiePath = ($basePath === '/' ? '/' : $basePath . '/');
 
-session_set_cookie_params([
-    'lifetime' => 60 * 60 * 24 * 28, // 28 Tage
-    'path' => $cookiePath,
-    'domain' => $_SERVER['HTTP_HOST'],
-    'secure' => $isHttps,
-    'httponly' => true,
-    'samesite' => 'Lax'
-]);
+if (!function_exists('getSessionCookieOptions')) {
+    function getSessionCookieOptions(): array
+    {
+        return [
+            'lifetime' => 60 * 60 * 24 * 28, // 28 Tage
+            'path' => '/',
+            'secure' => isHttpsRequest(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ];
+    }
+}
 
-session_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params(getSessionCookieOptions());
+    session_start();
+}
 
 // Dynamische Seiten nicht cachen (verhindert veraltete Anzeige bei F5 / alte MySQL-Daten)
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');

--- a/pages/login.php
+++ b/pages/login.php
@@ -36,7 +36,7 @@ try {
                         while (ob_get_level()) {
                             ob_end_clean();
                         }
-                        header('Location: /pages/onboarding.php', true, 302);
+                        header('Location: /index.php', true, 302);
                         exit;
                     }
                     error_log('[Login] missing token in response for ' . $email . ', keys=' . implode(',', array_keys($data)));

--- a/pages/logout.php
+++ b/pages/logout.php
@@ -15,12 +15,27 @@ if (isset($_POST['csrf_token']) && isset($_SESSION['csrf_token'])) {
 $_SESSION = array();
 clearApiToken();
 
+$sessionCookieOptions = getSessionCookieOptions();
+
 if (isset($_COOKIE[session_name()])) {
-    setcookie(session_name(), '', time() - 3600, '/', '', true, true);
+    setcookie(session_name(), '', [
+        'expires' => time() - 3600,
+        'path' => $sessionCookieOptions['path'],
+        'secure' => $sessionCookieOptions['secure'],
+        'httponly' => $sessionCookieOptions['httponly'],
+        'samesite' => $sessionCookieOptions['samesite'],
+    ]);
 }
+
 foreach (['remember_me', 'auth_token'] as $cookie) {
     if (isset($_COOKIE[$cookie])) {
-        setcookie($cookie, '', time() - 3600, '/', '', true, true);
+        setcookie($cookie, '', [
+            'expires' => time() - 3600,
+            'path' => '/',
+            'secure' => $sessionCookieOptions['secure'],
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
     }
 }
 


### PR DESCRIPTION
### Motivation

- Fix a login session bug where after successful login the user is redirected to `/index.php` but the session cookie was scoped too narrowly (e.g. `/pages`) so the browser didn't send it to `/index.php`.
- Provide a single, central session bootstrap so all pages use the same cookie params and `session_start()` behavior.

### Description

- Added a central session bootstrap in `includes/session.php` with `session_set_cookie_params()` called before `session_start()` and cookie options `path => '/'`, `httponly => true`, `samesite => 'Lax'`, and `secure` enabled conditionally for HTTPS; the start is idempotent via `session_status()`.
- Updated `pages/login.php` to keep `session_write_close()` before redirect and changed the post-login redirect to `/index.php` so the session cookie immediately applies to the target page.
- Aligned session cookie invalidation to the centralized options in `includes/header.php` (401 handling) and `pages/logout.php` so cookies are cleared with the same `path`/`secure`/`samesite` semantics.
- Removed prior dynamic app-subpath cookie scoping that could cause cookies to not be sent to root pages.

### Testing

- Ran PHP syntax checks: `php -l includes/session.php && php -l pages/login.php && php -l pages/logout.php && php -l includes/header.php` and they all returned no syntax errors (success).
- Launched local PHP dev server and verified HTTP response headers with `curl -D /tmp/login_headers.txt -c /tmp/fuel_cookies.txt http://127.0.0.1:8088/pages/login.php` which showed `Set-Cookie: PHPSESSID=...; path=/; HttpOnly; SameSite=Lax` (success).
- Verified the cookie is sent to the landing page with `curl -v -b /tmp/fuel_cookies.txt http://127.0.0.1:8088/index.php` which included `Cookie: PHPSESSID=...` on the request (success).
- Attempted a regression check for failed login, but the upstream auth request in this environment failed with `CONNECT tunnel failed, response 403`, so full end-to-end invalid-login verification against the real API was limited (external auth call failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990584dc7d8832eb0e2b81926ca1d90)